### PR TITLE
cl-gobject-introspection.asd: Add asdf:test-system support

### DIFF
--- a/cl-gobject-introspection.asd
+++ b/cl-gobject-introspection.asd
@@ -14,6 +14,8 @@
   :licence "BSD"
   :depends-on (:cffi :iterate :trivial-garbage)
   :serial t
+  :in-order-to ((test-op (load-op :cl-gobject-introspection-test)))
+  :perform (test-op (o c) (uiop:symbol-call :gir-test :main))
   :components ((:file "src/package")
                (:file "src/init")
                (:file "src/typelib")


### PR DESCRIPTION
Now you can use (adsf:test-system :cl-gobject-introspection) to run the unit test suite.

Take a look at the asdf test-op document for this.  This only works for ASDF3.  I think we need not to support ASDF2?
