### PR TITLE
Restore return-raw-pointer logic

### DIFF
--- a/src/function.lisp
+++ b/src/function.lisp
@@ -524,11 +524,13 @@
   (out-args :pointer) (n-out-args :int)
   (ret :pointer) (g-error :pointer))
 
-(defun build-function (info)
+(defun build-function (info &key return-raw-pointer)
   (multiple-value-bind (args-processor in-count out-count in-array-length-count)
       (get-args info)
     (let* ((name (info-get-name info))
-	   (res-trans (return-giarg info))
+	   (res-trans (if return-raw-pointer
+			  *raw-pointer-translator*
+			  (return-giarg info)))
 	   (caller-owns (callable-info-get-caller-owns info))
 	   (res-clear (ecase caller-owns
 			(:everything (translator-free res-trans))

--- a/src/object.lisp
+++ b/src/object.lisp
@@ -51,9 +51,16 @@
     (if function-info
 	(setf flags (function-info-get-flags function-info))
 	(error "Bad FFI constructor/function name ~a" name))
-    (if (or (constructor? flags) (class-function? flags))
-	(build-function function-info)
-	(error "~a is not constructor or class function" name))))
+    (cond
+      ((constructor? flags)
+       (let ((constructor (build-function function-info :return-raw-pointer t)))
+	 (lambda (&rest args)
+	   (let ((this (apply constructor args)))
+	     (object-setup-gc (build-object-ptr object-class this))))))
+      ((class-function? flags)
+       (build-function function-info))
+      (t
+       (error "~a is not constructor or class function" name)))))
 
 (defun object-class-build-method (object-class name)
   (let* ((info (object-class-info object-class))

--- a/src/struct.lisp
+++ b/src/struct.lisp
@@ -37,7 +37,9 @@
 	 (flags (if function-info (function-info-get-flags function-info))))
     (unless (and function-info (constructor? flags))
       (error "Bad FFI constructor name ~a" name))
-    (build-function function-info)))
+    (let ((constructor (build-function function-info :return-raw-pointer t)))
+      (lambda (&rest args)
+	(build-struct-ptr struct-class (apply constructor args))))))
 
 (defun struct-class-build-method (struct-class name)
   (let* ((info (struct-class-info struct-class))


### PR DESCRIPTION
Some Gtk object constructor return value type is GtkWidget instead of
real type, for example, gtk_window_new returns GtkWidget instead of
GtkWindow.  This needs to be worked around via original
return-raw-pointer logic, which is removed by mistake.  This patch
restore it.
