### PR TITLE
Only export in package.lisp

### DIFF
--- a/src/baseinfo.lisp
+++ b/src/baseinfo.lisp
@@ -96,19 +96,15 @@
 
 (defun info-get-type (info)
   (g-base-info-get-type (info-ptr info)))
-(export 'info-get-type)
 
 (cffi:defcfun (info-get-name "g_base_info_get_name") :string
   (info info-ffi))
-(export 'info-get-name)
 
 (cffi:defcfun (info-get-namespace "g_base_info_get_namespace") :string
   (info info-ffi))
-(export 'info-get-namespace)
 
 (cffi:defcfun (info-is-deprecated "g_base_info_is_deprecated") :boolean
   (info info-ffi))
-(export 'info-is-deprecated)
 
 (cffi:defcfun (info-get-attribute "g_base_info_get_attribute") :string
   (info info-ffi)
@@ -132,20 +128,15 @@
 	 ;; foreign-string-to-lisp
 	 (pprint (cons name value))))))
 
-(export 'info-get-attributes)
-
 (cffi:defcfun g-base-info-get-container info-ffi
   (info info-ffi))
 (defun info-get-container (info)
   (info-ffi-finalize (g-base-info-get-container info) nil))
-(export 'info-get-container)
 
 (cffi:defcfun (info-get-typelib "g_base_info_get_typelib") typelib-type
   (info info-ffi))
-(export 'info-get-typelib)
 
 (cffi:defcfun (info-equal "g_base_info_equal") :boolean
   (info1 info-ffi)
   (info2 info-ffi))
-(export 'info-equal)
 

--- a/src/function.lisp
+++ b/src/function.lisp
@@ -380,7 +380,6 @@
 	  ((:array :utf8 :filename)
 	   (error "array, utf8, filename must be pointer"))
 	  (t (find-build-general-translator tag))))))
-(export 'build-translator)
 
 (defmacro incf-giargs (giargs)
   `(setf ,giargs (cffi:mem-aptr ,giargs '(:union argument) 1)))

--- a/src/init.lisp
+++ b/src/init.lisp
@@ -108,8 +108,7 @@
        (defun ,name (info)
 	 (let ((n (,get-count-name info)))
 	   (iter (for i from 0 below n)
-		 (collect (info-ffi-finalize (,get-item info i))))))
-       (export ',name))))
+		 (collect (info-ffi-finalize (,get-item info i)))))))))
 
 
 (cffi:defbitfield connect-flags

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -7,8 +7,6 @@
   (:shadow #:get-properties)
   (:export 
    #:argument
-   #:enum-info-get-methods
-   #:build-translator
    #:base-info
    #:type-info
    #:callable-info
@@ -29,113 +27,126 @@
    #:constant-info
    #:arg-info
    
-   #:object-info-get-type-name 
-   #:registered-type-info-get-type-init
-   #:interface-info-get-prerequisites
-   #:type-info-get-interface
-   #:info-get-namespace
-   #:type-info-get-array-fixed-size
-   #:type-info-get-array-length
-   #:type-tag-to-string #:field-info-get-size
-   #:object-info-get-interfaces
-   #:vfunc-info-get-signal
    #:repository-get-dependencies
-   #:object-info-get-class-struct
-   #:info-get-name #:typelib-symbol
-   #:info-get-typelib
-   #:function-info-get-property
-   #:field-info-get-type
-   #:arg-info-get-ownership-transfer
-   #:vfunc-info-get-offset
-   #:type-info-is-zero-terminated
    #:repository-is-registered
    #:repository-find-by-gtype
-   #:union-info-get-discriminators
-   #:object-info-get-type-init
-   #:union-info-get-alignment
-   #:callable-info-get-args
-   #:arg-info-may-be-null
-   #:repository-require #:repository-new
-   #:field-info-get-offset
-   #:info-get-attributes
-   #:struct-info-get-fields
+   #:repository-require
    #:repository-get-shared-library
-   #:object-info-find-method
-   #:struct-info-is-gtype-struct
-   #:property-info-get-flags
-   #:arg-info-is-optional
-   #:property-info-get-type
-   #:union-info-is-discriminated
-   #:g-object-info-get-fields
-   #:struct-info-find-method
+   #:repository-new
    #:repository-get-version
-   #:info-get-container
-   #:object-info-get-abstract
-   #:object-info-get-constants
-   #:interface-info-find-method
-   #:arg-info-get-destroy
-   #:arg-info-is-caller-allocates
-   #:type-info-is-pointer
-   #:function-info-get-vfunc
-   #:object-info-get-parent
    #:repository-prepend-search-path
    #:repository-load-typelib
-   #:callable-info-may-return-null
-   #:with-typelibs #:repository-get-c-prefix
-   #:interface-info-get-signals
-   #:enum-info-get-storage-type
-   #:enum-info-get-values
-   #:union-info-get-discriminator-type
-   #:typelib-namespace
-   #:interface-info-get-iface-struct
-   #:type-info-get-param-type
-   #:callable-info-get-return-type
-   #:union-info-get-methods
-   #:type-info-get-tag #:value-info-get-value
-   #:object-info-get-signals
+   #:repository-get-c-prefix
    #:repository-find-by-name
-   #:object-info-find-vfunc
-   #:struct-info-get-methods
-   #:arg-info-get-scope
-   #:vfunc-info-get-invoker #:with-typelib
-   #:registered-type-info-get-type-name
    #:repository-get-infos
-   #:interface-info-get-vfuncs #:typelib-new
-   #:info-equal #:union-info-get-size
-   #:interface-info-find-vfunc
-   #:object-info-get-methods
-   #:signal-info-get-class-closure
    #:repository-get-typelib-path
    #:repository-get-loaded-namespaces
-   #:struct-info-get-size
-   #:vfunc-info-get-flags
-   #:arg-info-get-direction
    #:repository-get-search-path
-   #:signal-info-true-stops-emit
-   #:constant-info-get-value
-   #:signal-info-get-flags
-   #:arg-info-get-closure
-   #:info-is-deprecated
-   #:union-info-find-method
-   #:callable-info-get-caller-owns
-   #:function-info-get-flags
-   #:field-info-get-flags #:typelib-free
-   #:struct-info-is-foreign
-   #:arg-info-is-return-value
-   #:union-info-get-fields
-   #:union-info-get-discriminator-offset
-   #:constant-info-get-type
    #:repository-get-default
-   #:function-info-get-symbol
+   #:info-get-name
+   #:info-get-type
+   #:info-get-namespace
+   #:info-is-deprecated
+   #:info-get-typelib
+   #:info-get-attributes
+   #:info-get-container
+   #:info-equal
+   #:callable-info-get-args
+   #:callable-info-may-return-null
+   #:callable-info-get-return-type
+   #:callable-info-get-caller-owns
+   #:arg-info-get-ownership-transfer
+   #:arg-info-may-be-null
+   #:arg-info-is-optional
+   #:arg-info-get-destroy
+   #:arg-info-is-caller-allocates
+   #:arg-info-get-scope
+   #:arg-info-get-direction
+   #:arg-info-get-closure
+   #:arg-info-is-return-value
+   #:arg-info-get-type
+   #:type-tag-to-string
+   #:type-info-get-interface
+   #:type-info-get-array-fixed-size
+   #:type-info-get-array-length
+   #:type-info-is-zero-terminated
+   #:type-info-is-pointer
+   #:type-info-get-param-type
+   #:type-info-get-tag
    #:type-info-get-array-type
+   #:value-info-get-value
+   #:field-info-get-size
+   #:field-info-get-type
+   #:field-info-get-offset
+   #:field-info-get-flags
+   #:union-info-get-alignment
+   #:union-info-is-discriminated
+   #:union-info-get-discriminator-type
+   #:union-info-get-discriminator-offset
+   #:union-info-get-discriminators
+   #:union-info-get-methods
+   #:union-info-get-size
+   #:union-info-find-method
+   #:union-info-get-fields
+   #:struct-info-get-fields
+   #:struct-info-is-gtype-struct
+   #:struct-info-find-method
+   #:struct-info-get-methods
+   #:struct-info-get-size
+   #:struct-info-is-foreign
+   #:struct-info-get-alignment
+   #:registered-type-info-get-type-init
+   #:registered-type-info-get-type-name
+   #:registered-type-info-get-g-type
+   #:enum-info-get-storage-type
+   #:enum-info-get-values
+   #:enum-info-get-methods
+   #:object-info-get-type-name
+   #:object-info-get-interfaces
+   #:object-info-get-class-struct
+   #:object-info-get-type-init
+   #:object-info-find-method
+   #:object-info-get-abstract
+   #:object-info-get-constants
+   #:object-info-get-parent
+   #:object-info-get-signals
+   #:object-info-find-vfunc
+   #:object-info-get-methods
    #:object-info-get-vfuncs
    #:object-info-get-properties
+   #:object-info-get-fields
+   #:interface-info-get-prerequisites
+   #:interface-info-find-method
+   #:interface-info-get-signals
+   #:interface-info-get-iface-struct
+   #:interface-info-get-vfuncs
+   #:interface-info-find-vfunc
    #:interface-info-get-properties
-   #:registered-type-info-get-g-type
    #:interface-info-get-methods
-   #:arg-info-get-type #:info-get-type
-   #:struct-info-get-alignment
    #:interface-info-get-constants
+   #:property-info-get-flags
+   #:property-info-get-type
+   #:signal-info-get-class-closure
+   #:signal-info-true-stops-emit
+   #:signal-info-get-flags
+   #:vfunc-info-get-signal
+   #:vfunc-info-get-offset
+   #:vfunc-info-get-invoker
+   #:vfunc-info-get-flags
+   #:constant-info-get-value
+   #:constant-info-get-type
+   #:function-info-get-property
+   #:function-info-get-vfunc
+   #:function-info-get-flags
+   #:function-info-get-symbol
+   #:with-typelib
+   #:typelib-new
+   #:typelib-symbol
+   #:with-typelibs
+   #:typelib-namespace
+   #:typelib-free
+
+   #:build-translator
 
    #:ffi
    #:nget
@@ -143,4 +154,5 @@
    #:field
    #:property
    #:allocate-struct
-   #:free-struct))
+   #:free-struct
+   #:connect))

--- a/src/repository.lisp
+++ b/src/repository.lisp
@@ -29,27 +29,21 @@
   
   (defun repository-new ()
     (make-repository :ptr
-		     (g-object-newv (g-irepository-get-type) 0)))
-
-  (export 'repository-new))
+		     (g-object-newv (g-irepository-get-type) 0))))
 
 
 (cffi:defcfun (repository-get-default "g_irepository_get_default") repository-type)
-(export 'repository-get-default)
 
 
 (cffi:defcfun (repository-prepend-search-path "g_irepository_prepend_search_path") :void
   (directory :string))
-(export 'repository-prepend-search-path)
 
 
 (progn
   (cffi:defcfun g-irepository-get-search-path :pointer)
   
   (defun repository-get-search-path ()
-    (g-slist-to-list (g-irepository-get-search-path)))
-  
-  (export 'repository-get-search-path))
+    (g-slist-to-list (g-irepository-get-search-path))))
 
 
 (progn
@@ -61,23 +55,19 @@
   
   (defun repository-load-typelib (repository typelib &optional flags)
     (with-gerror err
-      (g-irepository-load-typelib repository typelib flags err)))
-  
-  (export 'repository-load-typelib))
+      (g-irepository-load-typelib repository typelib flags err))))
 
 
 (cffi:defcfun (repository-is-registered "g_irepository_is_registered") :boolean
   (repository repository-type)
   (namespace :string)
   (version :string))
-(export 'repository-is-registered)
 
 
 (def-info-func (repository-find-by-name g-irepository-find-by-name)
   (repository repository-type)
   (namespace :string)
   (name :string))
-(export 'repository-find-by-name)
 
 
 (progn
@@ -89,26 +79,21 @@
     (gerror :pointer))
   
   (defun repository-require (repository namespace version &optional flags)
-    (with-gerror err (g-irepository-require repository namespace version flags err)))
-  
-  (export 'repository-require))
+    (with-gerror err (g-irepository-require repository namespace version flags err))))
 
 
 (cffi:defcfun (repository-get-dependencies "g_irepository_get_dependencies") strv-ffi
   (repository repository-type)
   (namespace :string))
-(export 'repository-get-dependencies)
 
 
 (cffi:defcfun (repository-get-loaded-namespaces "g_irepository_get_loaded_namespaces") strv-ffi
   (repository repository-type))
-(export 'repository-get-loaded-namespaces)
 
 
 (def-info-func (repository-find-by-gtype g-irepository-find-by-gtype)
   (repository repository-type)
   (g-type :ulong))
-(export 'repository-find-by-gtype)
 
 (progn
   (cffi:defcfun g-irepository-get-n-infos :int
@@ -123,29 +108,23 @@
     (let ((n (g-irepository-get-n-infos repository namespace)))
       (iter (for i from 0 below n)
 	    (collect (info-ffi-finalize
-		      (g-irepository-get-info repository namespace i))))))
-
-  (export 'repository-get-infos))
+		      (g-irepository-get-info repository namespace i)))))))
 
 (cffi:defcfun (repository-get-typelib-path "g_irepository_get_typelib_path") :string
   (repository repository-type)
   (namespace :string))
-(export 'repository-get-typelib-path)
 
 (cffi:defcfun (repository-get-shared-library "g_irepository_get_shared_library") :string
   (repository repository-type)
   (namespace :string))
-(export 'repository-get-shared-library)
 
 (cffi:defcfun (repository-get-c-prefix "g_irepository_get_c_prefix") :string
   (repository repository-type)
   (namespace :string))
-(export 'repository-get-c-prefix)
 
 (cffi:defcfun (repository-get-version "g_irepository_get_version") :string
   (repository repository-type)
   (namespace :string))
-(export 'repository-get-version)
 
 ;; GOptionGroup * g_irepository_get_option_group (void);
 ;; gboolean       g_irepository_dump  (const char *arg, GError **error);
@@ -166,7 +145,6 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (def-info-func callable-info-get-return-type
   (callable-info info-ffi))
-(export 'callable-info-get-return-type)
 
 (cffi:defcenum transfer
     "Represent the transfer ownership information of a callable-info or a arg-info."
@@ -176,11 +154,9 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (cffi:defcfun (callable-info-get-caller-owns "g_callable_info_get_caller_owns") transfer
   (callable-info info-ffi))
-(export 'callable-info-get-caller-owns)
 
 (cffi:defcfun (callable-info-may-return-null "g_callable_info_may_return_null") :boolean
   (callable-info info-ffi))
-(export 'callable-info-may-return-null)
 
 (define-collection-getter callable-info-get-args
     g-callable-info-get-n-args g-callable-info-get-arg)
@@ -206,43 +182,33 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (cffi:defcfun (arg-info-get-direction "g_arg_info_get_direction") direction
   (arg-info info-ffi))
-(export 'arg-info-get-direction)
 
 (cffi:defcfun (arg-info-is-return-value "g_arg_info_is_return_value") :boolean
   (arg-info info-ffi))
-(export 'arg-info-is-return-value)
 
 (cffi:defcfun (arg-info-is-optional "g_arg_info_is_optional") :boolean
   (arg-info info-ffi))
-(export 'arg-info-is-optional)
 
 (cffi:defcfun (arg-info-is-caller-allocates "g_arg_info_is_caller_allocates") :boolean
   (arg-info info-ffi))
-(export 'arg-info-is-caller-allocates)
 
 (cffi:defcfun (arg-info-may-be-null "g_arg_info_may_be_null") :boolean
   (arg-info info-ffi))
-(export 'arg-info-may-be-null)
 
 (cffi:defcfun (arg-info-get-ownership-transfer "g_arg_info_get_ownership_transfer") transfer
   (arg-info info-ffi))
-(export 'arg-info-get-ownership-transfer)
 
 (cffi:defcfun (arg-info-get-scope "g_arg_info_get_scope") scope-type
   (arg-info info-ffi))
-(export 'arg-info-get-scope)
 
 (cffi:defcfun (arg-info-get-closure "g_arg_info_get_closure") :int
   (arg-info info-ffi))
-(export 'arg-info-get-closure)
 
 (cffi:defcfun (arg-info-get-destroy "g_arg_info_get_destroy") :int
   (arg-info info-ffi))
-(export 'arg-info-get-destroy)
 
 (def-info-func arg-info-get-type
   (arg-info info-ffi))
-(export 'arg-info-get-type)
 
 ;;;
 ;;; type-info
@@ -284,40 +250,31 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (cffi:defcfun (type-tag-to-string "g_type_tag_to_string") :string
   (tag type-tag))
-(export 'type-tag-to-string)
 
 (cffi:defcfun (type-info-is-pointer "g_type_info_is_pointer") :boolean
   (type-info info-ffi))
-(export 'type-info-is-pointer)
 
 (cffi:defcfun (type-info-get-tag "g_type_info_get_tag") type-tag
   (type-info info-ffi))
-(export 'type-info-get-tag)
 
 (def-info-func type-info-get-param-type
   (type-info info-ffi)
   (n :int))
-(export 'type-info-get-param-type)
 
 (def-info-func type-info-get-interface
   (type-info info-ffi))
-(export 'type-info-get-interface)
 
 (cffi:defcfun (type-info-get-array-length "g_type_info_get_array_length") :int
   (type-info info-ffi))
-(export 'type-info-get-array-length)
 
 (cffi:defcfun (type-info-get-array-fixed-size "g_type_info_get_array_fixed_size") :int
   (type-info info-ffi))
-(export 'type-info-get-array-fixed-size)
 
 (cffi:defcfun (type-info-is-zero-terminated "g_type_info_is_zero_terminated") :boolean
   (type-info info-ffi))
-(export 'type-info-is-zero-terminated)
 
 (cffi:defcfun (type-info-get-array-type "g_type_info_get_array_type") array-type
   (type-info info-ffi))
-(export 'type-info-get-array-type)
 
 ;(define-collection-getter type-info-get-error-domains
 ;    g-type-info-get-n-error-domains g-type-info-get-error-domain)
@@ -340,7 +297,6 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (cffi:defcfun (value-info-get-value "g_value_info_get_value") :long
   (value-info info-ffi))
-(export 'value-info-get-value)
 
 ;;;
 ;;; field-info
@@ -353,19 +309,15 @@ void gi_cclosure_marshal_generic (GClosure       *closure,
 
 (cffi:defcfun (field-info-get-flags "g_field_info_get_flags") field-info-flags
   (field-info info-ffi))
-(export 'field-info-get-flags)
 
 (cffi:defcfun (field-info-get-size "g_field_info_get_size") :int
   (field-info info-ffi))
-(export 'field-info-get-size)
 
 (cffi:defcfun (field-info-get-offset "g_field_info_get_offset") :int
   (field-info info-ffi))
-(export 'field-info-get-offset)
 
 (def-info-func field-info-get-type
   (field-info info-ffi))
-(export 'field-info-get-type)
 
 #|
 gboolean g_field_info_get_field (GIFieldInfo     *field_info,
@@ -388,15 +340,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (union-info-is-discriminated "g_union_info_is_discriminated") :boolean
   (union-info info-ffi))
-(export 'union-info-is-discriminated)
 
 (cffi:defcfun (union-info-get-discriminator-offset "g_union_info_get_discriminator_offset") :int
   (union-info info-ffi))
-(export 'union-info-get-discriminator-offset)
 
 (def-info-func union-info-get-discriminator-type
   (union-info info-ffi))
-(export 'union-info-get-discriminator-type)
 
 (define-collection-getter union-info-get-discriminators
     (g-union-info-get-n-fields :already-defined) g-union-info-get-discriminator)
@@ -404,15 +353,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func union-info-find-method
   (union-info info-ffi)
   (name :string))
-(export 'union-info-find-method)
 
 (cffi:defcfun (union-info-get-size "g_union_info_get_size") :int
   (union-info info-ffi))
-(export 'union-info-get-size)
 
 (cffi:defcfun (union-info-get-alignment "g_union_info_get_alignment") :int
   (union-info info-ffi))
-(export 'union-info-get-alignment)
 
 ;;;
 ;;; struct-info
@@ -427,23 +373,18 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func struct-info-find-method
   (struct-info info-ffi)
   (name :string))
-(export 'struct-info-find-method)
 
 (cffi:defcfun (struct-info-get-size "g_struct_info_get_size") :int
   (struct-info info-ffi))
-(export 'struct-info-get-size)
 
 (cffi:defcfun (struct-info-get-alignment "g_struct_info_get_alignment") :int
   (struct-info info-ffi))
-(export 'struct-info-get-alignment)
 
 (cffi:defcfun (struct-info-is-gtype-struct "g_struct_info_is_gtype_struct") :boolean
   (struct-info info-ffi))
-(export 'struct-info-is-gtype-struct)
 
 (cffi:defcfun (struct-info-is-foreign "g_struct_info_is_foreign") :boolean
   (struct-info info-ffi))
-(export 'struct-info-is-foreign)
 
 ;;;
 ;;; registered-type-info
@@ -451,15 +392,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (registered-type-info-get-type-name "g_registered_type_info_get_type_name") :string
   (registered-type-info info-ffi))
-(export 'registered-type-info-get-type-name)
 
 (cffi:defcfun (registered-type-info-get-type-init "g_registered_type_info_get_type_init") :string
   (registered-type-info info-ffi))
-(export 'registered-type-info-get-type-init)
 
 (cffi:defcfun (registered-type-info-get-g-type "g_registered_type_info_get_g_type") :int
   (registered-type-info info-ffi))
-(export 'registered-type-info-get-g-type)
 
 ;;;
 ;;; enum-info
@@ -474,7 +412,6 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (enum-info-get-storage-type "g_enum_info_get_storage_type") info-ffi
   (enum-info info-ffi))
-(export 'enum-info-get-storage-type)
 
 ;;;
 ;;; object-info
@@ -482,24 +419,20 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (object-info-get-type-name "g_object_info_get_type_name") :string
   (object-info info-ffi))
-(export 'object-info-get-type-name)
 
 (cffi:defcfun (object-info-get-type-init "g_object_info_get_type_init") :string
   (object-info info-ffi))
-(export 'object-info-get-type-init)
 
 (cffi:defcfun (object-info-get-abstract "g_object_info_get_abstract") :boolean
   (object-info info-ffi))
-(export 'object-info-get-abstract)
 
 (def-info-func object-info-get-parent
   (object-info info-ffi))
-(export 'object-info-get-parent)
 
 (define-collection-getter object-info-get-interfaces
     g-object-info-get-n-interfaces g-object-info-get-interface)
 
-(define-collection-getter g-object-info-get-fields
+(define-collection-getter object-info-get-fields
     g-object-info-get-n-fields g-object-info-get-field)
 
 (define-collection-getter object-info-get-properties
@@ -511,7 +444,6 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func object-info-find-method
   (object-info info-ffi)
   (name :string))
-(export 'object-info-find-method)
 
 (define-collection-getter object-info-get-signals
     g-object-info-get-n-signals g-object-info-get-signal)
@@ -522,14 +454,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func object-info-find-vfunc
   (object-info info-ffi)
   (name :string))
-(export 'object-info-find-vfunc)
 
 (define-collection-getter object-info-get-constants
     g-object-info-get-n-constants g-object-info-get-constant)
 
 (def-info-func object-info-get-class-struct
   (object-info info-ffi))
-(export 'object-info-get-class-struct)
 
 ;;;
 ;;; interface-info
@@ -547,7 +477,6 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func interface-info-find-method
   (interface-info info-ffi)
   (name :string))
-(export 'interface-info-find-method)
 
 (define-collection-getter interface-info-get-signals
     g-interface-info-get-n-signals g-interface-info-get-signal)
@@ -558,14 +487,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 (def-info-func interface-info-find-vfunc
   (interface-info info-ffi)
   (name :string))
-(export 'interface-info-find-vfunc)
 
 (define-collection-getter interface-info-get-constants
     g-interface-info-get-n-constants g-interface-info-get-constant)
 
 (def-info-func (interface-info-get-class-struct g-interface-info-get-iface-struct)
   (interface-info info-ffi))
-(export 'interface-info-get-iface-struct)
 
 ;;;
 ;;; property-info
@@ -585,11 +512,9 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (property-info-get-flags "g_property_info_get_flags") param-flags
   (property-info info-ffi))
-(export 'property-info-get-flags)
 
 (def-info-func property-info-get-type
   (property-info info-ffi))
-(export 'property-info-get-type)
 
 ;;;
 ;;; signal-info
@@ -607,15 +532,12 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (signal-info-get-flags "g_signal_info_get_flags") signal-flags
   (signal-info info-ffi))
-(export 'signal-info-get-flags)
 
 (def-info-func signal-info-get-class-closure
   (signal-info info-ffi))
-(export 'signal-info-get-class-closure)
 
 (cffi:defcfun (signal-info-true-stops-emit "g_signal_info_true_stops_emit") :boolean
   (signal-info info-ffi))
-(export 'signal-info-true-stops-emit)
 
 ;;;
 ;;; vfunc-info
@@ -629,19 +551,15 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (vfunc-info-get-flags "g_vfunc_info_get_flags") vfunc-info-flags
   (vfunc-info info-ffi))
-(export 'vfunc-info-get-flags)
 
 (cffi:defcfun (vfunc-info-get-offset "g_vfunc_info_get_offset") :int
   (vfunc-info info-ffi))
-(export 'vfunc-info-get-offset)
 
 (def-info-func vfunc-info-get-signal
   (vfunc-info info-ffi))
-(export 'vfunc-info-get-signal)
 
 (def-info-func vfunc-info-get-invoker
   (vfunc-info info-ffi))
-(export 'vfunc-info-get-invoker)
 
 ;;;
 ;;; constant-info
@@ -649,7 +567,6 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (def-info-func constant-info-get-type
   (constant-info info-ffi))
-(export 'constant-info-get-type)
 
 (progn 
   (cffi:defcfun g-constant-info-get-value :int
@@ -660,9 +577,7 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
     (cffi:with-foreign-object (value '(:pointer (:union argument)))
       (let ((trans (build-translator (constant-info-get-type constant-info))))
 	(g-constant-info-get-value constant-info value)
-	(funcall (translator->value trans) value))))
-  
-  (export 'constant-info-get-value))
+	(funcall (translator->value trans) value)))))
 
 ;;;
 ;;; function-info
@@ -679,19 +594,15 @@ gboolean g_field_info_set_field (GIFieldInfo     *field_info,
 
 (cffi:defcfun (function-info-get-symbol "g_function_info_get_symbol") :string
   (function-info info-ffi))
-(export 'function-info-get-symbol)
 
 (cffi:defcfun (function-info-get-flags "g_function_info_get_flags") function-info-flags
   (function-info info-ffi))
-(export 'function-info-get-flags)
 
 (def-info-func function-info-get-property
   (function-info info-ffi))
-(export 'function-info-get-property)
 
 (def-info-func function-info-get-vfunc
   (function-info info-ffi))
-(export 'function-info-get-vfunc)
 
 #|
 #define G_INVOKE_ERROR (g_invoke_error_quark ())

--- a/src/signal.lisp
+++ b/src/signal.lisp
@@ -99,4 +99,3 @@
                                       (cffi:null-pointer) 
                                       flags)))))
     handler-id))
-(export 'connect)

--- a/src/typelib.lisp
+++ b/src/typelib.lisp
@@ -28,11 +28,8 @@
 	  (setf (cffi:mem-aref buffer :uint8 i) b))
     (make-typelib :ptr (with-gerror err (g-typelib-new-from-memory buffer (length source) err)))))
 
-(export 'typelib-new)
-
 (cffi:defcfun (typelib-free "g_typelib_free") :void
   (typelib typelib-type))
-(export 'typelib-free)
 
 (defmacro with-typelib (var source &body body)
   `(let ((,var (typelib-new ,source)))
@@ -40,8 +37,6 @@
 	  (progn
 	    ,@body)
        (typelib-free ,var))))
-
-(export 'with-typelib)
 
 (defmacro with-typelibs ((&rest var-defs) &body body)
   `(let ,(iter (for vs on var-defs by #'cddr)
@@ -51,8 +46,6 @@
 	    ,@body)
        ,@(iter (for vs on var-defs by #'cddr)
 	       (collect `(typelib-free ,(first vs)))))))
-
-(export 'with-typelibs)
 
 (cffi:defcfun g-typelib-symbol :boolean
   (typelib typelib-type)
@@ -64,9 +57,5 @@
     (when (g-typelib-symbol typelib symbol-name s)
       (cffi:mem-ref s :pointer))))
 
-(export 'typelib-symbol)
-
 (cffi:defcfun (typelib-namespace "g_typelib_get_namespace") :string
   (typelib typelib-type))
-(export 'typelib-namespace)
-

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -25,7 +25,6 @@
   (v-size :uint)
   (v-string :pointer) ;; if :string, it frees pointer after setting it
   (v-pointer :pointer))
-(export 'argument)
 
 (defun argument->lisp-value (argument length type)
   (declare (ignore length))


### PR DESCRIPTION
Remove export function call in other lisp files.  Make sure all
previous exported symbols exported in package.lisp.  Reorder
exported symbols in classes in package.lisp.

Rename g-object-info-get-fields to object-info-get-fields.