### PR TITLE
Maze example

### DIFF
--- a/examples/flood-game/load.lisp
+++ b/examples/flood-game/load.lisp
@@ -38,7 +38,22 @@
                   (3 3 2 1 0 0 0 2 2 0 1 1)
                   (1 1 2 3 3 2 2 1 0 3 1 2))))
 
-;; (gtk-window-with-cairo-painting 'render-image-in-cairo-context)
 
 (visualize-solution-in-gtk-window
  '(3 2 1 2 0 1 3 2 3 0 2 1 0 3 2))
+
+;; (gtk-window-with-cairo-painting 'render-image-in-cairo-context)
+;; or without blocking REPL with slime-eval-defun or:
+;; (bordeaux-threads:make-thread
+;;  (lambda ()
+;;    (gtk-window-with-cairo-painting 'render-image-in-cairo-context))
+;;  :name "Flood Game GUI")
+;;
+;; timeout which connected to GTK thread works and GUI is redrawing
+;; for each 0.3 sec. So you can patch *image* or
+;; render-image-in-cairo-context and see results in window with little
+;; delay. Take notice this feature doesn't work in case:
+;;
+;; (gtk-window-with-cairo-painting #'render-image-in-cairo-context)
+;;
+;; ... with render-image-in-cairo-context patching.

--- a/examples/flood-game/load.lisp
+++ b/examples/flood-game/load.lisp
@@ -55,5 +55,4 @@
 ;; delay. Take notice this feature doesn't work in case:
 ;;
 ;; (gtk-window-with-cairo-painting #'render-image-in-cairo-context)
-;;
-;; ... with render-image-in-cairo-context patching.
+

--- a/examples/maze/load.lisp
+++ b/examples/maze/load.lisp
@@ -1,0 +1,37 @@
+
+(in-package :cl-user)
+
+(ql:quickload '(;; "cffi"
+                ;; "cffi-objects"
+                "cl-gobject-introspection"
+
+                ;; Accessible Cairo API through gobject introspection
+                ;; is quite poor
+                "cl-cairo2"))
+
+(let ((*default-pathname-defaults* 
+        (merge-pathnames #P"examples/maze/src/"
+                         (asdf:system-source-directory "cl-gobject-introspection"))))
+  (load #P"./package.lisp") 
+  (load #P"./maze.lisp")
+  (load #P"./maze-generator.lisp")
+  (load #P"./gui/drawing.lisp")
+  (load #P"./gui/edit.lisp")
+  (load #P"./gui/walking-through-maze.lisp"))
+
+(in-package :maze-example)
+
+(setf *random-state*
+      (make-random-state t))
+
+(defparameter *maze*
+  (generate-maze 10 8))
+
+(edit-maze-in-window *maze*)
+
+
+(walk-through-maze *maze*)
+;; Shortcuts:
+;; C-q  -  close window
+;; H    -  hide
+;; arrows for moving

--- a/examples/maze/load.lisp
+++ b/examples/maze/load.lisp
@@ -27,7 +27,7 @@
 (defparameter *maze*
   (generate-maze 10 8))
 
-(edit-maze-in-window *maze*)
+(edit-maze-in-window! *maze*)
 
 
 (walk-through-maze *maze*)

--- a/examples/maze/src/gui/drawing.lisp
+++ b/examples/maze/src/gui/drawing.lisp
@@ -1,0 +1,162 @@
+
+(in-package :maze-example)
+
+(defvar *gtk* (gir:require-namespace "Gtk"))
+(defvar *gdk* (gir:require-namespace "Gdk"))
+
+(defstruct (maze-geometry
+            (:constructor make-maze-geometry
+                (x y width height a nh nw)))
+  nh nw height width x y a)
+
+(defvar *maze-geometry*)
+
+(defmacro with-gtk-event-loop=window+drawing-area
+    ((window-symbol drawing-area-symbol
+      &key
+        protected-final-code
+        (window-title "Untitled"))
+     &body code)
+  (let ((code `((gir:invoke (*gtk* 'init) nil)
+                (let ((,window-symbol (gir:invoke (*gtk* "Window" 'new)
+                                                  (gir:nget *gtk*
+                                                            "WindowType"
+                                                            :toplevel))) 
+                      (,drawing-area-symbol (gir:invoke (*gtk* "DrawingArea"
+                                                               'new))))
+                  (setf (gir:property ,window-symbol 'title)
+                        ,window-title)
+                  (gir:invoke (,window-symbol "set_default_size")
+                              900 900)
+                  (gir:connect ,window-symbol :destroy
+                               (lambda (win)
+                                 (declare (ignore win)) 
+                                 (gir:invoke (*gtk* 'main-quit)))) 
+                  ,@code 
+                  (gir:invoke (,window-symbol 'add)
+                              ,drawing-area-symbol) 
+                  (gir:invoke (,window-symbol 'show-all))
+                  (gir:invoke (*gtk* 'main))
+                  (null ,window-symbol)))))
+    (if protected-final-code
+        `(unwind-protect (progn ,@code)
+           ,@protected-final-code)
+        `(progn ,@code))))
+
+(defmacro with-area-drawer-form ((drawing-area context-bind
+                                  &optional (drawing-area-bind
+                                             (gensym "DRAWING-AREA-")
+                                             drawing-area-bind-p))
+                                 &body code)
+  (let ((context-ptr-sym (gensym "CONTEXT-POINTER-"))
+        (size-requesters (list (gensym "WIDTH-REQUESTER-")
+                               (gensym "HEIGHT-REQUESTER-"))))
+    (flet (($size-setting-form (&rest hwlist)
+             (mapcan (lambda (sym requester)
+                       (list sym `(funcall ,requester)))
+                     hwlist
+                     size-requesters)))
+      `(let (,context-bind
+             ,@(mapcar (lambda (gir-method size-requester)
+                         `(,size-requester (gir:nget ,drawing-area
+                                                     ,gir-method)))
+                       '("get_allocated_width"
+                         "get_allocated_height")
+                       size-requesters))
+         (lambda (,drawing-area-bind ,context-ptr-sym)
+           ,@(unless drawing-area-bind-p
+               `((declare (ignore ,drawing-area-bind))))
+           (if ,context-bind
+               (with-slots ((h cairo:height)
+                            (w cairo:width))
+                   ,context-bind
+                 (setf ,@($size-setting-form 'w 'h)))
+               (setf ,context-bind
+                     (make-instance 'cairo:context
+                                    :pointer ,context-ptr-sym
+                                    ,@($size-setting-form
+                                       :width
+                                       :height))))
+           ,@code)))))
+
+(defun draw-hline (y x1 x2)
+  (cairo:move-to x1 y)
+  (cairo:line-to x2 y)
+  (cairo:stroke))
+
+(defun draw-vline (x y1 y2)
+  (cairo:move-to x y1)
+  (cairo:line-to x y2)
+  (cairo:stroke))
+
+
+(defun draw-maze-grid (x0 y0 cell-side maze-width maze-height nw nh)
+  (loop :for i :from 0 :to nh
+        :for y = (+ y0 (* cell-side i))
+        :with x1 = (+ x0 maze-width)
+        :do (draw-hline y x0 x1))
+  (loop :for i :from 0 :to nw 
+        :for x = (+ x0 (* cell-side i))
+        :with y1 = (+ y0 maze-height)
+        :do (draw-vline x y0 y1)))
+
+
+(defun draw-maze-walls (maze x0 y0 cell-side nw nh)
+  (flet (($snwall (v n)
+           (draw-vline (+ x0 (* v cell-side))
+                       (+ y0 (* n cell-side))
+                       (+ y0 (* (1+ n)
+                                cell-side))))
+         ($wewall (h n)
+           (draw-hline (+ y0 (* h cell-side))
+                       (+ x0 (* n cell-side))
+                       (+ x0 (* (1+ n)
+                                cell-side))))) 
+    (with-slots (we-walls sn-walls)
+        maze
+      (loop :for h :from 0 :to nh
+            :do (dotimes (n nw)
+                  (when (aref we-walls h n)
+                    ($wewall h n))))
+      (loop :for v :from 0 :to nw
+            :do (dotimes (n nh)
+                  (when (aref sn-walls v n)
+                    ($snwall v n)))))))
+
+(defun draw-maze (maze context)
+  (cairo:with-context (context)
+    (with-slots ((nh height) (nw width))
+        maze
+      (let* ((ymax  (cairo:height context))
+             (xmax (cairo:width context))
+             (size (* 0.95 (min ymax xmax)))
+             (cell-side (/ size (max nh nw)))) 
+        (let* ((mazeh (* nh cell-side))
+               (mazew (* nw cell-side)) 
+               (y0 (/ (- ymax mazeh)
+                      2))
+               (x0 (/ (- xmax mazew)
+                      2)))
+          (cairo:set-source-rgb 1 1 1)
+          (cairo:paint)
+          (cairo:set-source-rgb 0.6 0.6 0.6)
+          (cairo:set-line-width 5.0)
+          (draw-maze-grid x0 y0 cell-side mazew mazeh nw nh)
+
+          (cairo:set-source-rgb 0.1 0.1 0.1) 
+          (cairo:set-line-width 10.0)
+          (draw-maze-walls maze x0 y0 cell-side nw nh) 
+          (setf *maze-geometry*
+                (make-maze-geometry x0 y0 mazew mazeh cell-side nh nw)))))))
+
+(defun register-events (obj
+                        event-masks)
+  (gir:invoke
+   (obj 'set-events)
+   (let ((e (gir:nget *gdk* "EventMask")))
+     (reduce (lambda (s m)
+               (boole boole-ior
+                      s
+                      (funcall e m)))
+             (rest event-masks)
+             :initial-value (funcall e (first event-masks))))))

--- a/examples/maze/src/gui/edit.lisp
+++ b/examples/maze/src/gui/edit.lisp
@@ -1,0 +1,94 @@
+
+(in-package :maze-example)
+
+(defun check-vwall (v n maze-geometry)
+  (with-slots (nw nh)
+      maze-geometry
+    (when (and (<= 0 v nw)
+               (<= 0 n (- nh 1)))
+      (list :vwall v n))))
+
+(defun check-hwall (h n maze-geometry)
+  (with-slots (nw nh)
+      maze-geometry
+    (when (and (<= 0 h nh)
+               (<= 0 n (- nw 1)))
+      (list :hwall h n))))
+
+(let ((d 0.15))
+  (defun clickpoint->wallid (x y maze-geometry)
+    (multiple-value-bind (xif yif)
+        (with-slots (a (x0 x) (y0 y))
+            maze-geometry 
+          (values (/ (- x x0)
+                     a)
+                  (/ (- y y0)
+                     a)))
+      (multiple-value-bind (xi dx)
+          (round xif)
+        (multiple-value-bind (yi dy)
+            (round yif)
+          (let ((a (< (abs dx) d))
+                (b (< (abs dy) d)))
+            (macrolet (($hwall ()
+                         `(check-hwall yi
+                                       (floor xif)
+                                       maze-geometry))
+                       ($vwall ()
+                         `(check-vwall xi
+                                       (floor yif)
+                                       maze-geometry)))
+              (cond
+                ((and a (not b))
+                 ($vwall))
+                ((and (not a) b)
+                 ($hwall))
+                ((and a b)
+                 (if (eq (> dy dx)
+                         (> dy (- dx)))
+                     ($vwall)
+                     ($hwall)))))))))))
+
+(defun edit-wall (wallid maze)
+  (destructuring-bind (type i1 i2)
+      wallid 
+    (let* ((a (ecase type
+                (:vwall (maze-sn-walls maze))
+                (:hwall (maze-we-walls maze))))
+           (v (aref a i1 i2)))
+      (setf (aref a i1 i2)
+            (not v)))))
+
+(defmacro with-event-button-handling ((object-reciever cursor-x cursor-y)
+                                       &body code)
+  "object-reciever must be a symbol which addresed to gtk object"
+  (let ((event-sym (gensym "EVENT-"))
+        (event-class-sym (gensym "EVENT-CLASS")))
+    `(gir:connect ,object-reciever :button-press-event
+                  (let ((,event-class-sym (gir:nget *gdk* "EventButton")))
+                    (lambda (,object-reciever ,event-sym) 
+                      (let* ((,event-sym (gir::build-struct-ptr ,event-class-sym
+                                                                ,event-sym)))
+                        (let ((,cursor-x (gir:field ,event-sym "x"))
+                              (,cursor-y (gir:field ,event-sym "y")))
+                          ,@code)))))))
+
+(defun edit-maze-in-window! (maze)
+  (let ((*maze-geometry* nil)) 
+    (with-gtk-event-loop=window+drawing-area
+        (window drawing-area
+         :window-title "Maze editor")
+      (gir:connect drawing-area :draw
+                   (with-area-drawer-form (drawing-area context)
+                     (draw-maze maze context)))
+      (with-event-button-handling (drawing-area x y)
+        (when *maze-geometry*
+          (let ((wallid (clickpoint->wallid x y
+                                            *maze-geometry*)))
+            (when wallid
+              (edit-wall wallid maze)
+              (gir:invoke (drawing-area
+                           :queue-draw)))))) 
+      (register-events drawing-area
+                       '(:button-press-mask))))
+  maze)

--- a/examples/maze/src/gui/walking-through-maze.lisp
+++ b/examples/maze/src/gui/walking-through-maze.lisp
@@ -1,0 +1,125 @@
+
+(in-package :maze-example)
+
+(defun event->key (ev)
+  (let ((k (gir:field ev "keyval")) 
+        (state (gir:field ev "state"))
+        (modifiers (list)))
+    (dolist (mdef '((#b1    :shift)
+                    (#b100  :ctrl)
+                    (#b1000 :alt)))
+      (destructuring-bind (int modifier)
+          mdef
+        (unless (zerop (logand int state))
+          (push modifier modifiers))))
+    (values (case k
+              (65361 :left-arrow)
+              (65362 :up-arrow)
+              (65363 :right-arrow)
+              (65364 :down-arrow) 
+              (otherwise k))
+            modifiers)))
+
+
+(let ((2pi (* 2 pi)))
+  (defun draw-player-location (player-location cairo-context)
+    (cairo:with-context (cairo-context)
+      (destructuring-bind (x . y) player-location
+        (with-slots (a (x0 x) (y0 y))
+            *maze-geometry*
+          (let ((x (+ x0 (* a (+ x 0.5))))
+                (y (+ y0 (* a (+ y 0.5))))
+                (r (* 0.4 a)))
+            (cairo:set-source-rgb 0.984 0.129 0.129)
+            (cairo:set-line-width 0.0)
+            (cairo:arc x y r 0 2pi)
+            (cairo:fill-path)))))))
+
+(defun player-move (key player-location maze)
+  (macrolet (($with-model (maze-binds &body code)
+               `(with-slots ,maze-binds maze
+                  (destructuring-bind (x . y) player-location
+                    ,@code))))
+    (case key
+      (:up-arrow
+       ($with-model (we-walls)
+                    (unless (or (zerop y) (aref we-walls y x))
+                      (cons x (- y 1)))))
+      (:down-arrow
+       ($with-model (we-walls height)
+                    (unless (or (>= y (1- height))
+                                (aref we-walls (1+ y) x))
+                      (cons x (1+ y)))))
+      (:left-arrow
+       ($with-model (sn-walls)
+                    (unless (or (zerop x) (aref sn-walls x y))
+                      (cons (- x 1) y))))
+      (:right-arrow
+       ($with-model (sn-walls width)
+                    (unless (or (>= x (1- width))
+                                (aref sn-walls (1+ x) y))
+                      (cons (1+ x) y))))
+      (otherwise nil))))
+
+
+(defmacro with-event-key-handling ((object-reciever key &optional modifiers)
+                                   &body code)
+  "object-reciever must be a symbol which addresed to gtk object"
+  (let ((event-sym (gensym "EVENT-"))
+        (event-class-sym (gensym "EVENT-CLASS")))
+    `(gir:connect ,object-reciever :key-press-event
+                  (let ((,event-class-sym (gir:nget *gdk* "EventKey")))
+                    (lambda (,object-reciever ,event-sym) 
+                      (let* ((,event-sym (gir::build-struct-ptr ,event-class-sym
+                                                                ,event-sym)))
+                        (multiple-value-bind (,key ,@(when modifiers
+                                                       `(,modifiers)))
+                            (event->key ,event-sym)
+                          ,@code)))))))
+
+
+
+(defun walk-through-maze (maze &optional (x0 0) (y0 0)) 
+  (let ((*maze-geometry* nil)
+        (player-location (cons x0 y0)))
+    (with-gtk-event-loop=window+drawing-area
+        (window drawing-area
+         :window-title "Maze")
+      (let ((id nil)
+            (hided-p nil)
+            (drawer (with-area-drawer-form (drawing-area context)
+                      (draw-maze maze context)
+                      (draw-player-location player-location
+                                            context)))
+            (drawerh (with-area-drawer-form (drawing-area context)
+                       (draw-maze maze context))))
+        (flet (($switch-mode (drawer)
+                 (when id
+                   (gir:disconnect drawing-area id))
+                 (setf id
+                       (gir:connect drawing-area :draw
+                                    drawer))))
+          ($switch-mode drawer)
+          (with-event-key-handling (window key mod)
+            (format *standard-output*
+                    "Key: ~A~%"
+                    (list key mod))
+            (unless hided-p
+              (let ((location (player-move key player-location maze)))
+                (when location
+                  (setf player-location location)
+                  (gir:invoke (drawing-area
+                               :queue-draw)))))
+            (cond
+              ((and (eq 113 key) 
+                    (member :ctrl mod)) ; 'C-q'
+               (gir:invoke (window :close)))
+              ((eq 72 key) ; 'H' key
+               (if hided-p
+                   ($switch-mode drawer)
+                   ($switch-mode drawerh))
+               (setf hided-p (not hided-p))
+               (gir:invoke (drawing-area
+                            :queue-draw))))))) 
+      (register-events window
+                       '(:key-press-mask)))))

--- a/examples/maze/src/maze-generator.lisp
+++ b/examples/maze/src/maze-generator.lisp
@@ -1,0 +1,129 @@
+
+(in-package :maze-example)
+
+(defun make-fully-walled-maze (width height)
+  (let ((sn-walls (make-array (list (1+ width)
+                                    height)
+                              :initial-element t))
+        (we-walls (make-array (list (1+ height)
+                                    width)
+                              :initial-element t))) 
+    (make-maze :height height
+               :width width
+               :sn-walls sn-walls
+               :we-walls we-walls)))
+
+(defmacro do-xy-visiting-array ((array x y)
+                                &body code)
+  (let ((height-s (gensym "HEIGHT-"))
+        (width-s (gensym "WIDTH-")))
+    `(destructuring-bind (,width-s ,height-s)
+         (array-dimensions ,array)
+       (dotimes (,y ,height-s)
+         (dotimes (,x ,width-s)
+           ,@code)))))
+
+(defun whole-maze-is-visited? (visiting-array)
+  (block fun
+    (do-xy-visiting-array (visiting-array x y)
+      (unless (aref visiting-array x y)
+        (return-from fun nil)))
+    t))
+
+(defun not-visited-neighbors (cell visiting-array)
+  (let ((neighbors (list :north :east :south :west)))
+    (destructuring-bind (width height)
+        (array-dimensions visiting-array)
+      (destructuring-bind (x . y)
+          cell
+        (flet (($delete-neighbor! (n)
+                 (setf neighbors (delete n neighbors))))
+          (macrolet (($check-direction! (direction
+                                         border-limit-condition
+                                         nx ny)
+                       `(when (or ,border-limit-condition
+                                  (aref visiting-array ,nx ,ny))
+                          ($delete-neighbor! ,direction))))
+            ($check-direction! :east (= x (- width 1))
+                               (+ x 1) y)
+            ($check-direction! :west (= x 0)
+                               (- x 1) y)
+            ($check-direction! :north (= y 0)
+                               x (- y 1))
+            ($check-direction! :south (= y (- height 1))
+                               x (+ y 1))))))
+    neighbors))
+
+(defun dig-in! (maze cell direction)
+  (destructuring-bind (x . y)
+      cell
+    (with-slots (sn-walls we-walls)
+        maze
+      (macrolet (($dig (&rest aref-args)
+                   `(setf (aref ,@aref-args)
+                          nil)))
+        (ecase direction
+          (:east
+           ($dig sn-walls
+                 (1+ x)
+                 y)
+           (values (1+ x)
+                   y))
+          (:west
+           ($dig sn-walls x y)
+           (values (- x 1)
+                   y))
+          (:north
+           ($dig we-walls y x)
+           (values x (- y 1)))
+          (:south ($dig we-walls
+                        (1+ y)
+                        x)
+           (values x (1+ y))))))))
+
+(defun get-random-unvisited-cell (visiting-array)
+  (macrolet (($do-each-unvisited-cell ((x y)
+                                       &body code)
+               `(do-xy-visiting-array (visiting-array ,x ,y)
+                  (unless (aref visiting-array ,x ,y)
+                    ,@code))))
+    (let* ((lucky-num (let ((c 0))
+                        ($do-each-unvisited-cell (x y)
+                          (incf c)) 
+                        (random c))))
+      (block f
+        (let ((i 0))
+          ($do-each-unvisited-cell (x y)
+            (if (= lucky-num i)
+                (return-from f (values x y))
+                (incf i))))))))
+
+(defun generate-maze (width height
+                          &aux (x 0) (y 0))
+  (let* ((maze (make-fully-walled-maze width height)) 
+         (visiting-array (make-array (list width height)
+                                     :initial-element nil))
+         (cell-stack (list))
+         c)
+    (flet (($visit-cell (x y)
+             (setf (aref visiting-array x y)
+                   t
+                   c (cons x y))))
+      ($visit-cell x y)
+      (loop :until (whole-maze-is-visited? visiting-array) 
+            :do (let ((nlist (not-visited-neighbors c visiting-array)))
+                  (cond
+                    (nlist
+                     (push c cell-stack)
+                     (let ((dir (nth (random (length nlist))
+                                     nlist))) 
+                       (multiple-value-bind (x y)
+                           (dig-in! maze c dir) 
+                         ($visit-cell x y))))
+                    (cell-stack
+                     (setf c (pop cell-stack)))
+                    (t
+                     (multiple-value-bind (x y)
+                         (get-random-unvisited-cell visiting-array) 
+                       ($visit-cell x y)))))
+            :finally (return maze)))))

--- a/examples/maze/src/maze.lisp
+++ b/examples/maze/src/maze.lisp
@@ -1,0 +1,37 @@
+
+
+(in-package :maze-example)
+
+(defstruct maze
+  height
+  width
+  sn-walls
+  we-walls)
+
+(defun make-empty-maze (width height)
+  (let ((sn-walls (make-array (list (1+ width)
+                                    height)
+                              :initial-element nil))
+        (we-walls (make-array (list (1+ height)
+                                    width)
+                              :initial-element nil))) 
+    (make-maze :height height
+               :width width
+               :sn-walls sn-walls
+               :we-walls we-walls)))
+
+(defun make-basic-maze (width height)
+  (let ((maze (make-empty-maze width height)))
+    (with-slots (sn-walls we-walls)
+        maze
+      (macrolet (($border-building-loop (walls 
+                                         border-width
+                                         walls-count-1)
+                   `(dotimes (i ,border-width)
+                      (setf (aref ,walls 0 i)
+                            t
+                            (aref ,walls ,walls-count-1 i)
+                            t))))
+        ($border-building-loop sn-walls height width)
+        ($border-building-loop we-walls width height)))
+    maze))

--- a/examples/maze/src/package.lisp
+++ b/examples/maze/src/package.lisp
@@ -1,0 +1,5 @@
+
+(in-package cl-user)
+
+(cl:defpackage maze-example
+  (:use #:cl))


### PR DESCRIPTION
  Warning! I have an issue with this example. edit-maze-in-window!
  works fine if I use my touchpad, but if I launch
  edit-maze-in-window! and use my usb mouse I get
  COMMON-LISP:DIVISION-BY-ZERO error.
 It was tested only with sbcl 1.4.0.