### PR TITLE
default-flags does not work

### DIFF
--- a/examples/hello-world.lisp
+++ b/examples/hello-world.lisp
@@ -21,6 +21,6 @@
 (defun main ()
   (let ((app (gir:invoke (*gtk* "Application" 'new)
                          "com.example.helloworld"
-                         (gir:nget *gio* "ApplicationFlags" :default-flags))))
+                         (gir:nget *gio* "ApplicationFlags" :flags_none))))
     (gir:connect app :activate #'activate)
     (gir:invoke (app 'run) nil)))


### PR DESCRIPTION
For some reason, `:default_flags` do not work for me. Inspecting the error shows the following:

```
#<GIR:ENUM-DESC {1003AE7613}>
--------------------
Class: #<STANDARD-CLASS GIR:ENUM-DESC>
--------------------
 Group slots by inheritance [ ]
 Sort slots alphabetically  [X]

All Slots:
[ ]  METHODS-DICT = NIL
[ ]  NAME         = "ApplicationFlags"
[ ]  VALUES-DICT  = (("flags_none" . 0) ("is_service" . 1) ("is_launcher" . 2) ("handles_open" . 4) ("handles_command_line" . 8) ("send_environment" . 16) ("non_unique" . 32) ("can_override_app_id" . 64) ("allow_replacement" . 128) ("replace" . 256))

```